### PR TITLE
BUG FIX - Prisma Deployment Errors

### DIFF
--- a/pages/api/home/home.tsx
+++ b/pages/api/home/home.tsx
@@ -431,7 +431,7 @@ export const getServerSideProps: GetServerSideProps = async ({
   const session = await getServerSession(req, res, authOptions);
   let prompts = null;
   let conversations = null;
-  const root = process.env.VERCEL_URL ?? process.env.NEXTAUTH_URL;
+  const root = process.env.NEXTAUTH_URL ?? process.env.VERCEL_URL;
   // if user is logged in, then fetch their prompts from the database
   if (session?.user?.id) {
     const promptsResponse: { prompts: PromptDatabase[] } = await fetch(

--- a/pages/api/home/home.tsx
+++ b/pages/api/home/home.tsx
@@ -431,10 +431,11 @@ export const getServerSideProps: GetServerSideProps = async ({
   const session = await getServerSession(req, res, authOptions);
   let prompts = null;
   let conversations = null;
+  const root = process.env.VERCEL_URL ?? process.env.NEXTAUTH_URL;
   // if user is logged in, then fetch their prompts from the database
   if (session?.user?.id) {
     const promptsResponse: { prompts: PromptDatabase[] } = await fetch(
-      `${process.env.NEXTAUTH_URL}/${API_LINKS.promptGetAll}`,
+      `${root}/${API_LINKS.promptGetAll}`,
       {
         method: 'POST',
         headers: {
@@ -442,7 +443,9 @@ export const getServerSideProps: GetServerSideProps = async ({
         },
         body: JSON.stringify({ id: session.user.id }),
       },
-    ).then((response) => response.json());
+    )
+      .then((response) => response.json())
+      .catch((error) => console.error(error));
 
     prompts = promptsResponse.prompts?.map((prompt) => ({
       ...prompt,
@@ -451,16 +454,15 @@ export const getServerSideProps: GetServerSideProps = async ({
     }));
 
     const conversationsResponse: { conversations: ConversationDatabase[] } =
-      await fetch(
-        `${process.env.NEXTAUTH_URL}/${API_LINKS.conversationGetAll}`,
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({ id: session.user.id }),
+      await fetch(`${root}/${API_LINKS.conversationGetAll}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
         },
-      ).then((response) => response.json());
+        body: JSON.stringify({ id: session.user.id }),
+      })
+        .then((response) => response.json())
+        .catch((error) => console.error(error));
 
     conversations = conversationsResponse.conversations?.map(
       (conversation) => ({

--- a/pages/api/home/home.tsx
+++ b/pages/api/home/home.tsx
@@ -431,7 +431,7 @@ export const getServerSideProps: GetServerSideProps = async ({
   const session = await getServerSession(req, res, authOptions);
   let prompts = null;
   let conversations = null;
-  const root = process.env.NEXTAUTH_URL ?? process.env.VERCEL_URL;
+  const root = process.env.NEXTAUTH_URL ?? `https://${process.env.VERCEL_URL}`;
   // if user is logged in, then fetch their prompts from the database
   if (session?.user?.id) {
     const promptsResponse: { prompts: PromptDatabase[] } = await fetch(
@@ -447,14 +447,14 @@ export const getServerSideProps: GetServerSideProps = async ({
       .then((response) => response.json())
       .catch((error) => console.error(error));
 
-    prompts = promptsResponse.prompts?.map((prompt) => ({
+    prompts = promptsResponse?.prompts?.map((prompt) => ({
       ...prompt,
       // match modelId with correct model before defining prompts
       model: OpenAIModels[prompt.modelId as OpenAIModelID],
     }));
 
     const conversationsResponse: { conversations: ConversationDatabase[] } =
-      await fetch(`${root}/${API_LINKS.conversationGetAll}`, {
+      await fetch(`${root}${API_LINKS.conversationGetAll}`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -464,7 +464,7 @@ export const getServerSideProps: GetServerSideProps = async ({
         .then((response) => response.json())
         .catch((error) => console.error(error));
 
-    conversations = conversationsResponse.conversations?.map(
+    conversations = conversationsResponse?.conversations?.map(
       (conversation) => ({
         ...conversation,
         model: OpenAIModels[conversation.modelId as OpenAIModelID],

--- a/utils/app/api.ts
+++ b/utils/app/api.ts
@@ -20,12 +20,12 @@ export const getEndpoint = (plugin: Plugin | null) => {
 };
 
 export const API_LINKS = {
-  conversationGetAll: '/api/conversations/get-all-conversations',
-  conversationUpdate: '/api/conversations/update-conversation',
-  messageCreate: '/api/messages/create-message',
-  messageGetAll: '/api/messages/get-all-messages',
-  promptGetAll: '/api/prompts/get-all-prompts',
-  promptUpdate: '/api/prompts/update-prompt',
+  conversationGetAll: 'api/conversations/get-all-conversations',
+  conversationUpdate: 'api/conversations/update-conversation',
+  messageCreate: 'api/messages/create-message',
+  messageGetAll: 'api/messages/get-all-messages',
+  promptGetAll: 'api/prompts/get-all-prompts',
+  promptUpdate: 'api/prompts/update-prompt',
 };
 type APILinks = typeof API_LINKS;
 type APILink = APILinks[keyof APILinks];


### PR DESCRIPTION
This PR fixes a number of deployment errors related to fetching from the NextJS's `getServerSideProps` function.

- Removes extra backslashes from the URL
- Provides a fallback `VERCEL_URL` which represents the deployment URL and includes the protocol schema (`https://`)
- Marks the response as possibly undefined using TypeScript's optional chaining